### PR TITLE
propagate labels from secretdef, move update to annotations

### DIFF
--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -23,9 +23,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
+const (
+	Group   = "secrets-manager.tuenti.io"
+	Version = "v1alpha1"
+)
+
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "secrets-manager.tuenti.io", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: Group, Version: Version}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/controllers/secretdefinition_controller.go
+++ b/controllers/secretdefinition_controller.go
@@ -51,6 +51,16 @@ type SecretDefinitionReconciler struct {
 	WatchNamespaces      map[string]bool
 }
 
+// Annotations to skip when copying from a SecretDef to a Secret
+var annotationsToSkip = map[string]bool{
+	corev1.LastAppliedConfigAnnotation: true,
+}
+
+// skipCopyAnnotation returns true if we should skip copying the annotation with the given annotation key
+func skipCopyAnnotation(key string) bool {
+	return annotationsToSkip[key]
+}
+
 // Helper functions to check and remove string from a slice of strings.
 func containsString(slice []string, s string) bool {
 	for _, item := range slice {
@@ -142,6 +152,9 @@ func (r *SecretDefinitionReconciler) upsertSecret(sDef *smv1alpha1.SecretDefinit
 	}
 
 	for k, v := range sDef.Annotations {
+		if skipCopyAnnotation(k) {
+			continue
+		}
 		annotations[k] = v
 	}
 

--- a/controllers/secretdefinition_controller_test.go
+++ b/controllers/secretdefinition_controller_test.go
@@ -133,7 +133,8 @@ var _ = Describe("SecretsManager", func() {
 				Namespace: "default",
 				Name:      "secretdef-labels",
 				Annotations: map[string]string{
-					"tekton.dev/git-0": "github.com",
+					"tekton.dev/git-0":                         "github.com",
+					"kubernetes.io/last-applied-configuration": "test",
 				},
 				Labels: map[string]string{
 					"test.example.com/name": "test",
@@ -286,9 +287,14 @@ var _ = Describe("SecretsManager", func() {
 				"test.example.com/name":        "test"}))
 
 			annotations := secret.GetObjectMeta().GetAnnotations()
+			// lastUpdateTime annotation is created
 			_, ok := annotations["secrets-manager.tuenti.io/lastUpdateTime"]
 			Expect(ok).To(BeTrue())
+			// annotations from the SecretDef are passed to the secret
 			Expect(annotations["tekton.dev/git-0"]).To(Equal("github.com"))
+			// annotations to be skipped are not copied
+			_, ok2 := annotations["kubernetes.io/last-applied-configuration"]
+			Expect(ok2).ToNot(BeNil())
 		})
 		It("Create a secretdefinition in a non-watched namespace", func() {
 			r2 := getReconciler()

--- a/controllers/secretdefinition_controller_test.go
+++ b/controllers/secretdefinition_controller_test.go
@@ -132,6 +132,9 @@ var _ = Describe("SecretsManager", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "default",
 				Name:      "secretdef-labels",
+				Annotations: map[string]string{
+					"tekton.dev/git-0": "github.com",
+				},
 				Labels: map[string]string{
 					"test.example.com/name": "test",
 					"name":                  "secret-labels",
@@ -285,6 +288,7 @@ var _ = Describe("SecretsManager", func() {
 			annotations := secret.GetObjectMeta().GetAnnotations()
 			_, ok := annotations["secrets-manager.tuenti.io/lastUpdateTime"]
 			Expect(ok).To(BeTrue())
+			Expect(annotations["tekton.dev/git-0"]).To(Equal("github.com"))
 		})
 		It("Create a secretdefinition in a non-watched namespace", func() {
 			r2 := getReconciler()

--- a/controllers/secretdefinition_controller_test.go
+++ b/controllers/secretdefinition_controller_test.go
@@ -254,7 +254,6 @@ var _ = Describe("SecretsManager", func() {
 			Expect(res).To(Equal(reconcile.Result{}))
 		})
 		It("Create a secretdefinition and read the labels and annotations", func() {
-			//decodedBytes, _ := base64.StdEncoding.DecodeString(encodedValue)
 			err := r.Create(context.Background(), sdWithLabels)
 			Expect(err).To(BeNil())
 			res, err2 := r.Reconcile(reconcile.Request{


### PR DESCRIPTION
This adds label propagation to secrets and updates the existing labels & annotations. 

The "managed-by" label has been updated to follow: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels

And the updatedAt has been moved to an annotation as per k8s guidelines. 